### PR TITLE
Update default qemu version to 7.1.0

### DIFF
--- a/cli/config.yml
+++ b/cli/config.yml
@@ -19,11 +19,11 @@ versions:
 
   default: &ver_def
     debian: &ver_debian_def
-      base: "7.0"
-      rev: "+dfsg-7"
+      base: "7.1"
+      rev: "+dfsg-2"
     fedora: &ver_fedora_def
-      base: "7.0.0"
-      rev: "3.fc37"
+      base: "7.1.0"
+      rev: "3.fc38"
 
 archs:
 


### PR DESCRIPTION
```
Check Debian
  Current version: 7.0+dfsg-7
  Latest upstream: 7.1+dfsg-2
Check Fedora
  Current version: ('7.0.0', '3.fc37')
  Latest upstream: ('7.1.0', '3.fc38')
```